### PR TITLE
[CRITICAL] banned exec

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -3,7 +3,7 @@ Configs for the bot
 '''
 
 # expressions which are banned
-banned = ['quit', 'input', 'open', 'import', 'exit']
+banned = ['quit', 'input', 'open', 'import', 'exit','exec']
 
 # timeout in seconds
 TIMEOUT = 6


### PR DESCRIPTION
# banned exec
banned exec in config.py because it was the cause of a major security flaw
this changes must be implemented otherwise the whole server will be easly attacked