### PR TITLE
Preprocessor feature for imports

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -13,3 +13,25 @@ I have limited resources.
 You may increase the timeout and run this bot on your own server if required.'''
 
 RESTRICT_MESSAGE = f'☹️ SECURITY ISSUE:\nYou have used a restricted word \n{BANNED}'
+# sequence to put before an import
+# es: "#:>imp-time" is valid if the IMPCHRSEQ is "#:>" and "imp-time" is in the IMPORTS_MAP
+# this IMP_TOKEN is supposed to have a # as first charachter because if the preprocessor doesn't
+# find a corrispondency will leave the #:>imp-somehthing as is
+IMP_TOKEN = "#:>"
+# avabile imports via preprocessor
+IMPORTS_MAP = {
+    "imp-time": "import time",
+    "imp-time-func": "from time import time",
+    # difflib has a function aboout files but not this from
+    "imp-sequencematcher-obj": "from difflib import SequenceMatcher",
+    "imp-get_close_matches-func": "from difflib import get_close_matches"  # the same for this
+    "imp-pprint": "import pprint",
+    "imp-pprint-func": "from pprint import pprint",
+    "imp-random": "import random",
+    "imp-os": "print('lol we are not so dumb bro, you CANT import os')",
+    "imp-struct": "import struct",
+    "imp-string": "import string",
+    "imp-math": "import math",
+    "imp-this": "import this",
+    "imp-antigravity": "print('https://xkcd.com/353/')"
+}

--- a/bot/config.py
+++ b/bot/config.py
@@ -24,7 +24,7 @@ IMPORTS_MAP = {
     "imp-time-func": "from time import time",
     # difflib has a function aboout files but not this from
     "imp-sequencematcher-obj": "from difflib import SequenceMatcher",
-    "imp-get_close_matches-func": "from difflib import get_close_matches"  # the same for this
+    "imp-get_close_matches-func": "from difflib import get_close_matches",  # the same for this
     "imp-pprint": "import pprint",
     "imp-pprint-func": "from pprint import pprint",
     "imp-random": "import random",

--- a/bot/execute_code.py
+++ b/bot/execute_code.py
@@ -5,7 +5,7 @@ import logging
 from subprocess import TimeoutExpired
 import subprocess
 import multiprocessing
-from .config import BANNED, TIMEOUT, TIMEOUT_MESSAGE, RESTRICT_MESSAGE
+from .config import BANNED, TIMEOUT, TIMEOUT_MESSAGE, RESTRICT_MESSAGE, IMP_TOKEN, IMPORTS_MAP
 
 
 def contains_restricted(input_text):
@@ -14,6 +14,22 @@ def contains_restricted(input_text):
         # block usage of this words for security and performance issues
         return True
     return False
+
+
+def preprocessor(input_text: str) -> str:
+    '''
+    this function is a preprocessor that replace lines according to IMP_MAP
+    if the string is not finded the line will remain the same,
+    this preprocessor has an intentional unflexible syntax and it not support spaces before
+    the token or after the string
+    '''
+    code_lines = input_text.splitlines()
+    ppdict_keys = IMPORTS_MAP.keys()
+    for i in range(len(code_lines)):
+        if IMP_TOKEN in code_lines[i][:len(IMP_TOKEN)]:
+            if code_lines[i][len(IMP_TOKEN):] in ppdict_keys:
+                code_lines[i] = IMPORTS_MAP[code_lines[i][len(IMP_TOKEN):]]
+    return "\n".join(code_lines)
 
 
 def run(update) -> str:
@@ -58,7 +74,7 @@ def run(update) -> str:
 
         if contains_restricted(input_text):
             return RESTRICT_MESSAGE
-        stdout, stderr = execute_py(input_text)
+        stdout, stderr = execute_py(preprocessor(input_text))
         if str(stdout) or str(stderr):
             out = f'{stdout} \n{stderr}'
             return out


### PR DESCRIPTION
# Preprocessor feature for imports
this feature allow some imports according to:
1) `IMPORTS_MAP` that has "whitelisted" imports
2) `IMP_TOKEN` preprocessor token now `#:>`
it replaces lines, nothing more nothing less
## Preprocessor demo:
before preprocessor:
```
#:>imp-time
#:>dafsgdffdsdg
#:>imp-this
#:>imp-sys
print(time.time())
```
after preprocessor:
```
import time
#:>dafsgdffdsdg
import this
#:>imp-sys
print(time.time())
```
**_NOTES:_**
_sys is not whitelisted as import nor as "imp-sys"
dafsgdffdsdg is not an avabile preprocessor directive_

## WARNING ⚠ the added modules they shouldn't have any access to files but please recheck anyway